### PR TITLE
feat: Add support for specifing path to db with chat in entrypoints

### DIFF
--- a/libs/creative-assistant/creative_assistant/__init__.py
+++ b/libs/creative-assistant/creative_assistant/__init__.py
@@ -22,4 +22,4 @@ __all__ = [
   'CreativeAssistant',
   'Message',
 ]
-__version__ = '0.4.0'
+__version__ = '0.5.0'

--- a/libs/creative-assistant/creative_assistant/assistant.py
+++ b/libs/creative-assistant/creative_assistant/assistant.py
@@ -45,6 +45,18 @@ Here are the tools you have: {tools_descriptions}
 """
 
 
+class CreativeAssistantRequest(pydantic.BaseModel):
+  """Specifies structure of request for interacting with assistant.
+
+  Attributes:
+    question: Question to the assistant.
+    chat_id: Optional chat_id to resume conversation.
+  """
+
+  question: str
+  chat_id: str | None = None
+
+
 class CreativeAssistantResponse(pydantic.BaseModel):
   """Defines LLM response and its meta information.
 
@@ -221,6 +233,7 @@ def bootstrap_assistant(
   parameters: dict[str, str | int | float] | None = None,
   verbose: bool = False,
   tools: str = 'All',
+  db_uri: str | None = None,
 ) -> CreativeAssistant:
   """Builds CreativeAssistant with injected tools.
 
@@ -228,6 +241,7 @@ def bootstrap_assistant(
     parameters:  Parameters for assistant and its tools instantiation.
     verbose: Whether to display additional logging information.
     tools: Which tools to setup during the bootstrap.
+    db_uri: Connection string for storing chats.
 
   Returns:
     Assistant with injected tools.
@@ -261,6 +275,9 @@ def bootstrap_assistant(
     llm=llms.create_llm(**base_llm_parameters),
     tools=found_tools,
     verbose=verbose,
+    chats_service=chat_service.ChatService(
+      chat_repository=chat_service.ChatRepository(db_uri)
+    ),
   )
 
 

--- a/libs/creative-assistant/creative_assistant/chat_service.py
+++ b/libs/creative-assistant/creative_assistant/chat_service.py
@@ -25,9 +25,10 @@ from creative_assistant.models import chat as ch
 class ChatRepository(repositories.SqlAlchemyRepository):
   """Repository for storing chats."""
 
-  def __init__(self, db_url) -> None:
+  def __init__(self, db_url: str | None = None) -> None:
     """Initializes ChatRepository."""
     super().__init__(db_url, orm_model=ch.Chat, primary_key='chat_id')
+    super().initialize()
 
 
 class MessageRepository(repositories.SqlAlchemyRepository):
@@ -36,6 +37,7 @@ class MessageRepository(repositories.SqlAlchemyRepository):
   def __init__(self, db_url) -> None:
     """Initializes MessageRepository."""
     super().__init__(db_url, orm_model=ch.Message, primary_key='message_id')
+    super().initialize()
 
 
 class ChatService:

--- a/libs/creative-assistant/creative_assistant/entrypoints/cli.py
+++ b/libs/creative-assistant/creative_assistant/entrypoints/cli.py
@@ -17,7 +17,6 @@
 
 import argparse
 import sys
-import uuid
 
 import dotenv
 from rich import console, prompt, text
@@ -31,8 +30,12 @@ def main():  # noqa D103
   parser.add_argument(
     '--chat-id',
     dest='chat_id',
-    default=str(uuid.uuid1()),
     help='Optional chat_id to resume conversation',
+  )
+  parser.add_argument(
+    '--db-uri',
+    dest='db_uri',
+    help='Database connection string to store and retrieve chats',
   )
   parser.add_argument(
     '--verbose',
@@ -54,6 +57,7 @@ def main():  # noqa D103
   creative_assistant = assistant.bootstrap_assistant(
     verbose=args.verbose,
     tools=args.tools,
+    db_uri=args.db_uri,
   )
   rich_console = console.Console()
   if args.question:
@@ -68,7 +72,7 @@ def main():  # noqa D103
   else:
     question = prompt.Prompt.ask('Enter your question')
     while question:
-      result = creative_assistant.interact(question)
+      result = creative_assistant.interact(question, args.chat_id)
       assistant_logger.info(
         '[Session: %s, Prompt: %s]: Message: %s',
         result.chat_id,


### PR DESCRIPTION
* Add db-uri parameters during assistant bootstrap; if not specified use in-memory db.
* Add full support for in-memory db in repositories.
* Move CreativeAssistantRequest to assistant module.
* When interacting with assistant, return full response (including chat_id) to the caller.

Change-Id: I3a9795b43ff15023dd7e57c0defce83ec201766b
